### PR TITLE
Corrige lógica para lidar com duplos (RR/rr)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -12,16 +12,8 @@ namespace Cebolinha
 
             Console.WriteLine();
             string textoDigitado = Console.ReadLine();
-            string RecebeTexto = textoDigitado.Replace("r", "l").Replace("R", "L").Replace("rr", "l").Replace("RR", "L");
+            string RecebeTexto = textoDigitado.Replace("rr","l").Replace("rR","l").Replace("RR","L").Replace("Rr","L").Replace("r","l").Replace("R","L");
             Console.WriteLine(RecebeTexto);
-           
-
-           
-          
-            
-
-         
-         
 
         }
     }


### PR DESCRIPTION
Se usar o replace para singulares primeiro, eles vão duplicar de qualquer maneira. Neste caso, substitui-se da maior grandeza (duplos) e então, os singulares.